### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 on:
     workflow_dispatch:
     pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/joepitt91/bind9_to_panos/security/code-scanning/1](https://github.com/joepitt91/bind9_to_panos/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required. Since this workflow only needs to read the repository contents to run Pylint, the `contents: read` permission is sufficient. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
